### PR TITLE
Add support for interrupts

### DIFF
--- a/bin/ti
+++ b/bin/ti
@@ -99,7 +99,7 @@ def action_fin(time):
     store.dump(data)
 
     if interrupted is not None:
-        print('Interrupt %s is done, you\'re back to working on %s' % (current['name'], interrupted['name']))
+        print('%s is done, you\'re back to working on %s.' % (current['name'], interrupted['name']))
     else:
         print('So you stopped working on ' + current['name'] + '.')
 

--- a/test/interrupt.t
+++ b/test/interrupt.t
@@ -1,0 +1,19 @@
+Setup
+
+  $ export SHEET_FILE=$TMP/sheet-actions
+  $ alias ti="$TESTDIR/../bin/ti"
+
+Go two deep in interrupts
+
+  $ ti o task
+  Start working on task.
+  $ ti i interrupt1
+  Interrupting task with interrupt: interrupt1. You are now 1 deep in interrupts.
+  $ ti i interrupt2
+  Interrupting interrupt: interrupt1 with interrupt: interrupt2. You are now 2 deep in interrupts.
+  $ ti f
+  interrupt: interrupt2 is done, you're back to working on interrupt: interrupt1.
+  $ ti f
+  interrupt: interrupt1 is done, you're back to working on task.
+  $ ti f
+  So you stopped working on task.


### PR DESCRIPTION
For example (from the test):

```
  $ ti o task
  Start working on task.
  $ ti i interrupt1
  Interrupting task with interrupt: interrupt1. You are now 1 deep in interrupts.
  $ ti i interrupt2
  Interrupting interrupt: interrupt1 with interrupt: interrupt2. You are now 2 deep in interrupts.
  $ ti f
  interrupt: interrupt2 is done, you're back to working on interrupt: interrupt1.
  $ ti f
  interrupt: interrupt1 is done, you're back to working on task.
  $ ti f
  So you stopped working on task.
```

Also supports a time argument, same as `on`.
