### PR TITLE
Fix interrupts so that only the current task is on the clock.

### DIFF
--- a/bin/ti
+++ b/bin/ti
@@ -59,7 +59,7 @@ class JsonStore(object):
 
 
 def get_current(data):
-    return (data['interrupt_stack'] or data['work'])[-1]
+    return data['work'][-1]
 
 
 def action_on(name, time):
@@ -87,19 +87,25 @@ def action_fin(time):
 
     data = store.load()
 
+    current = data['work'][-1]
+
     if len(data['interrupt_stack']) > 0:
-        current = data['interrupt_stack'].pop()
-        interrupted = get_current(data)
-        data['work'].insert(-1, current)
+        #get the name of the next task to be restarted from the interrupt stack
+        interrupted = data['interrupt_stack'].pop()
+
+        entry = {
+            'name': interrupted,
+            'start': time
+        }
+        data['work'].append(entry)
     else:
-        current = data['work'][-1]
         interrupted = None
 
     current['end'] = time
     store.dump(data)
 
     if interrupted is not None:
-        print('%s is done, you\'re back to working on %s.' % (current['name'], interrupted['name']))
+        print('%s is done, you\'re back to working on %s.' % (current['name'], interrupted))
     else:
         print('So you stopped working on ' + current['name'] + '.')
 
@@ -112,13 +118,20 @@ def action_interrupt(name, time):
         data['interrupt_stack'] = []
     interrupt_stack = data['interrupt_stack']
 
+    #end the current task
+    interrupted = get_current(data)
+    interrupted['end'] = time
+
+    #add the current task name to the interrupt_stack
+    interrupt_stack.append(interrupted['name'])
+
+    #add the new task to the tip of the work stream
     entry = {
-        'name': 'interrupt: ' + name,
+        'name': name,
         'start': time
     }
 
-    interrupted = get_current(data)
-    interrupt_stack.append(entry)
+    data['work'].append(entry)
     store.dump(data)
 
     current = data['work'][-1]
@@ -176,9 +189,17 @@ def action_status():
             .format(current, diff))
 
 
+    if len(data['interrupt_stack']) > 0:
+        indent = '  '
+        print('Interrupt Stack:')
+        print(indent + current['name'])
+        for interrupt in reversed(data['interrupt_stack']):
+            indent = indent + '  '
+            print(indent + interrupt)
+
 def action_log(period):
     data = store.load()
-    work = data['work'] + data['interrupt_stack']
+    work = data['work']
     log = defaultdict(lambda: {'delta': timedelta()})
     current = None
 

--- a/test/interrupt.t
+++ b/test/interrupt.t
@@ -8,12 +8,12 @@ Go two deep in interrupts
   $ ti o task
   Start working on task.
   $ ti i interrupt1
-  Interrupting task with interrupt: interrupt1. You are now 1 deep in interrupts.
+  Interrupting task with interrupt1. You are now 1 deep in interrupts.
   $ ti i interrupt2
-  Interrupting interrupt: interrupt1 with interrupt: interrupt2. You are now 2 deep in interrupts.
+  Interrupting interrupt1 with interrupt2. You are now 2 deep in interrupts.
   $ ti f
-  interrupt: interrupt2 is done, you're back to working on interrupt: interrupt1.
+  interrupt2 is done, you're back to working on interrupt1.
   $ ti f
-  interrupt: interrupt1 is done, you're back to working on task.
+  interrupt1 is done, you're back to working on task.
   $ ti f
   So you stopped working on task.


### PR DESCRIPTION
The interrupt stack is just a list of tasks to jump back to after the current task completes.  Also added the interrupt stack to the status output to show the task order.


(If you like the #9 Colorize task names, I have another branch with those changes combined with these.) 