### PR TITLE
Add 'list' command

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,10 +81,18 @@ Tag your activities for fun and profit.
 
     $ ti tag imp
 
-Get a log of all activities with the `log` (or `l`) command.
+Get a log of all activities ordered by time spent with the `log` (or `l`) command.
 
     $ ti log
 
+List activities in time order with the `list` command.
+
+    $ ti list
+
+Pass a filter to the `list` command to total up the hours of matching records.
+
+    $ ti list +project-x
+    
 ## Command reference
 
 Run `ti -h` (or `--help` or `help` or just `h`) to get a short command summary
@@ -176,6 +184,13 @@ adds the note `Discuss this with the other team.` to the current activity.
 
 Gives a table like representation of all activities and total time spent on each
 of them.
+
+### list
+- Syntax: `ti (list) [filter-1, filter-n]
+
+Provides a list of all activities in the order they occurred.  Passing one or more 
+filters will only show matching records and calculate a total number of hours
+for the matches.  Works well for a timecard for a project or a time period.
 
 ## Time format
 

--- a/bin/ti
+++ b/bin/ti
@@ -14,6 +14,7 @@ Usage:
   ti (l|log) [today]
   ti (e|edit)
   ti (i|interrupt)
+  ti (list) [<filter-1> <filter-2> ... <filter-n>]
   ti --no-color
   ti -h | --help
 
@@ -39,6 +40,12 @@ from os import path
 import sys
 
 from colorama import *
+import dateutil.parser
+from dateutil import tz
+LOCAL = tz.tzlocal()
+UTC = tz.gettz('UTC')
+
+
 
 class JsonStore(object):
 
@@ -235,6 +242,43 @@ def action_log(period):
                 end=' ← working\n' if current == name else '\n')
 
 
+def action_list(filters):
+    data = store.load()
+    work = data['work']
+    current = None
+
+    n = datetime.utcnow()
+    total_dur = timedelta(0)
+
+    for item in sorted(work, key=(lambda x: x['start'])):
+        start_time = dateutil.parser.parse(item['start']).astimezone(LOCAL)
+        if 'end' in item:
+            end_time = dateutil.parser.parse(item['end']).astimezone(LOCAL)
+        else:
+            end_time = datetime.utcnow().replace(tzinfo=UTC).astimezone(LOCAL) #wow Python.  That's pretty crappy.
+            current = item['name']
+
+        dur = end_time - start_time
+        dur_str = ':'.join(str(dur).split('.')[:1]) #just show hours, minutes, seconds
+
+        line = start_time.strftime('%Y-%m-%d %H:%M')+'->'+end_time.strftime('%H:%M')+' ('+ dur_str +'):  '+ item['name']
+      
+        if (current):
+            line = line + green(' (current)')
+
+        if (filters):
+            #if filters are defined, only print str if line contains all of the filters
+            if all(x in line for x in filters):
+                print(line)
+                total_dur = total_dur + dur
+        else:
+            print(line)
+            total_dur = total_dur + dur
+
+    if (filters):
+        print( '                 Total: ('+':'.join( str(total_dur).split('.')[:1] ) +')' )
+
+
 def action_edit():
     if 'EDITOR' not in os.environ:
         print("Please set the 'EDITOR' environment variable", file=sys.stderr)
@@ -414,6 +458,10 @@ def parse_args(argv=sys.argv):
             'name': tail[0],
             'time': to_datetime(' '.join(tail[1:])),
         }
+
+    elif head in ['list']:
+        fn = action_list
+        args = {'filters': tail[0:] if tail else None}
 
     else:
         helpful_exit("I don't understand '" + head + "'")


### PR DESCRIPTION
The list command lists all activities in the time order they occurred.
The output contains the dates and times the activities covered along with
their names.  The list command takes optional filters that limit the
activities displayed.  For example, filtering the list by a date limits
the resulting activities to those that match the date.  By doing this,
you can easily see all of the activities form a a certain day.  You
can filter by more than one string at a time, so you could show only
activities for +project-x and 2015-05-24.  When filters are provided,
a total number of hours is calculated for the matching activities.
This makes the list command an excellent way to fill out a timecard
or run reports for time spent on a specific project.
