### PR TITLE
Don't store color in JSON store

### DIFF
--- a/bin/ti
+++ b/bin/ti
@@ -141,7 +141,7 @@ def action_interrupt(name, time):
     interrupt_stack.append(interrupted)
     store.dump(data)
 
-    action_on('interrupt: ' + green(name), time)
+    action_on('interrupt: ' + name, time)
     print('You are now %d deep in interrupts.' % len(interrupt_stack))
 
 


### PR DESCRIPTION
Fixed bug where interrupt creation was passing a colorized name into action_on,
which in turn was storing color codes in the JSON store.
Referenced by sharat87/ti#13.
