### PR TITLE
Fix './ti log' pipe issue

### DIFF
--- a/bin/ti
+++ b/bin/ti
@@ -231,8 +231,8 @@ def action_log(period):
         log[name]['tmsg'] = ', '.join(tmsg)[::-1].replace(',', ' &'[::-1], 1)[::-1]
 
     for name, item in sorted(log.items(), key=(lambda x: x[1]), reverse=True):
-        print(name.ljust(name_col_len), ' ∙∙ ', item['tmsg'],
-                end=' ← working\n' if current == name else '\n')
+        print(name.ljust(name_col_len), ' ∙∙ '.encode('utf-8'), item['tmsg'],
+                end=' ← working\n'.encode('utf-8') if current == name else '\n')
 
 
 def action_edit():

--- a/test/format.t
+++ b/test/format.t
@@ -23,7 +23,7 @@ Another one, with notes
   $ ti on another-project
   Start working on another-project.
   $ ti note a simple note
-  Yep, noted to `another-project`.
+  Yep, noted to another-project.
 
 End and check
 

--- a/test/log.t
+++ b/test/log.t
@@ -1,0 +1,33 @@
+Setup
+
+  $ export SHEET_FILE=$TMP/sheet-on
+  $ alias ti="$TESTDIR/../bin/ti --no-color"
+
+Start working
+
+  $ ti on my-project
+  Start working on my-project.
+  $ test -f $SHEET_FILE
+  $ ti fin
+  So you stopped working on my-project.
+
+Start working while working
+
+  $ ti on project1
+  Start working on project1.
+  $ ti fin
+  So you stopped working on project1.
+  $ ti on project2
+  Start working on project2.
+  $ ti log
+  project2    \xe2\x88\x99\xe2\x88\x99   \xe2\x86\x90 working (esc)
+  project1    \xe2\x88\x99\xe2\x88\x99   (esc)
+  my-project  \xe2\x88\x99\xe2\x88\x99   (esc)
+  $ ti log | grep project1
+  project1    \xe2\x88\x99\xe2\x88\x99   (esc)
+  $ ti fin
+  So you stopped working on project2.
+  $ ti log
+  project2    \xe2\x88\x99\xe2\x88\x99   (esc)
+  project1    \xe2\x88\x99\xe2\x88\x99   (esc)
+  my-project  \xe2\x88\x99\xe2\x88\x99   (esc)

--- a/test/note.t
+++ b/test/note.t
@@ -15,12 +15,12 @@ Start working and then note
   $ ti on donkey-music
   Start working on donkey-music.
   $ ti note hee-haw
-  Yep, noted to `donkey-music`.
+  Yep, noted to donkey-music.
 
 Add another longer note
 
   $ ti note holla hoy with a longer musical? note
-  Yep, noted to `donkey-music`.
+  Yep, noted to donkey-music.
 
 Note with external editor
 FIXME: Need a better EDITOR to test with

--- a/test/status.t
+++ b/test/status.t
@@ -12,22 +12,22 @@ Status when not working
 
 Status after on-ing a task
 
-  $ ti on conqering-the-world
-  Start working on conqering-the-world.
+  $ ti on conquering-the-world
+  Start working on conquering-the-world.
   $ ti status
-  You have been working on `conqering-the-world` for less than a minute.
+  You have been working on conquering-the-world for less than a minute.
 
 After adding tags
 
   $ ti tag awesome
   Okay, tagged current work with 1 tags.
   $ ti status
-  You have been working on `conqering-the-world` for less than a minute.
+  You have been working on conquering-the-world for less than a minute.
 
 Status after fin-ing it
 
   $ ti fin
-  So you stopped working on conqering-the-world.
+  So you stopped working on conquering-the-world.
   $ ti status
   For all I know, you aren't working on anything. I don't know what to do.
   See `ti -h` to know how to start working.


### PR DESCRIPTION
Fix for issue #11: Unicode characters printed out with the log were causing problems when
being piped to other programs.  Fixed by explicitly encoding strings to utf-8.

Another option would be to change these to ascii characters.
