### PR TITLE
removes explicit decoding of arguments

### DIFF
--- a/bin/ti
+++ b/bin/ti
@@ -349,7 +349,10 @@ def helpful_exit(msg=__doc__):
 def parse_args(argv=sys.argv):
     global use_color
 
-    argv = [arg.decode('utf-8') for arg in argv]
+    try: 
+      argv = [arg.decode('utf-8') for arg in argv]
+    except AttributeError:
+      pass
 
     if '--no-color' in argv:
         use_color = False


### PR DESCRIPTION
the elements of argv are already str objects which are already considered decoded by python 3.5.2. This commit adds a try-except block for the AttributeError that is raised. This should keep the decoding intact for python2 while silently dropping the error in python3

fixes #32